### PR TITLE
add support for a new requirement type called 'distro-manual'

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -71,7 +71,8 @@
 			    "type": "string",
 			    "enum": [
 				"2020.03.02",
-				"2020.04.30"
+				"2020.04.30",
+				"2022.07.25"
 			    ]
 			}
 		    },
@@ -182,6 +183,45 @@
 	    "uniqueItems": true,
 	    "items": {
 		"oneOf": [
+		    {
+			"type": "object",
+			"properties": {
+			    "name": {
+				"type": "string",
+				"minLength": 1
+			    },
+			    "type": {
+				"type": "string",
+				"enum": [
+				    "distro-manual"
+				]
+			    },
+			    "distro-manual_info": {
+				"type": "object",
+				"properties": {
+				    "packages": {
+					"type": "array",
+					"minItems": 1,
+					"uniqueuItems": true,
+					"items": {
+					    "type": "string",
+					    "minLength": 1
+					}
+				    }
+				},
+				"required": [
+				    "packages"
+				],
+				"additionalProperties": false
+			    }
+			},
+			"required": [
+			    "name",
+			    "type",
+			    "distro-manual_info"
+			],
+			"additionalProperties": false
+		    },
 		    {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
- the new 'distro-manual' type allows URLs of distro compliant
  packages (ie. an RPM file) to be specified

- the URL is downloaded (with available retry logic) and then the file
  is installed with the appropriate distro tool

- this replaces some use cases of the 'manual' type and is
  functionally the same but it allows for automatic retry logic to be
  implemented transparently to the user