### PR TITLE
add distro-manual package validation prior to attempting to install

### DIFF
--- a/workshop.pl
+++ b/workshop.pl
@@ -1322,6 +1322,26 @@ if (opendir(NORMAL_ROOT, "/")) {
                                 $download_attempts++;
                                 if ($rc != 0) {
                                     sleep 1;
+                                } else {
+                                    my $operation_cmd;
+                                    if ($userenv_json->{'userenv'}{'properties'}{'packages'}{'type'} eq 'rpm') {
+                                        $operation_cmd = "rpm --install --verbose --test " . $download_filename;
+                                    } elsif ($userenv_json->{'userenv'}{'properties'}{'packages'}{'type'} eq 'pkg') {
+                                        $operation_cmd = "";
+                                    } else {
+                                        logger('info', "failed validation\n", 5);
+                                        logger('error', "Unsupported userenv package type encountered [$userenv_json->{'userenv'}{'properties'}{'packages'}{'type'}]\n");
+                                        quit_files_coro($files_requirements_present, $files_channel);
+                                        exit(get_exit_code('unsupported_package_manager'));
+                                    }
+
+                                    if ($operation_cmd ne '') {
+                                        ($command, $command_output, $rc) = run_command("$operation_cmd");
+                                        $install_cmd_log .= sprintf($command_logger_fmt, $command, $rc, $command_output);
+                                        if ($rc != 0) {
+                                            sleep 1;
+                                        }
+                                    }
                                 }
                             }
                             if ($rc == 0) {


### PR DESCRIPTION
- Seeing some instances of the download completing but it being an
  html page (with an error) rather than the actual package to be
  installed.  This appears transient (ie. bad behavior on the part of
  the server).

- By detecting this (via package testing) during the download loop
  then the download can be retried via the existing retry logic.