### PR TITLE
update crucible-ci

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -1,34 +1,175 @@
 name: crucible-ci
 
 on:
-  # run on push or pull request events for the master branch only
   pull_request:
     branches: [ master ]
-
-  # allow for manual invocation from the actions tab
+    paths-ignore:
+    - LICENSE
+    - '**.md'
+    - .github/workflows/faux-crucible-ci.yaml
+    - 'docs/**'
   workflow_dispatch:
 
 jobs:
-  crucible-ci:
+  generate-job-matrix-parameters:
     runs-on: ubuntu-latest
-
+    outputs:
+      userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
+      endpoints_github: ${{ steps.get-endpoints-github.outputs.endpoints }}
+      endpoints_self: ${{ steps.get-endpoints-self.outputs.endpoints }}
+      benchmarks_github: ${{ steps.get-benchmarks-github.outputs.benchmarks }}
+      benchmarks_self: ${{ steps.get-benchmarks-self.outputs.benchmarks }}
     steps:
-    - name: Checkout workshop
-      uses: actions/checkout@v2
-      with:
-        path: workshop
-
-    - name: Checkout crucible-ci
+    - name: checkout crucible-ci
       uses: actions/checkout@v2
       with:
         repository: perftool-incubator/crucible-ci
         ref: main
         path: crucible-ci
+    - name: checkout rickshaw
+      uses: actions/checkout@v2
+      with:
+        repository: perftool-incubator/rickshaw
+        ref: master
+        path: rickshaw
+    - name: run get-userenvs
+      id: get-userenvs
+      uses: ./crucible-ci/.github/actions/get-userenvs
+      with:
+        rickshaw-directory: "./rickshaw"
+    - name: run get-endpoints-github
+      id: get-endpoints-github
+      uses: ./crucible-ci/.github/actions/get-endpoints
+      with:
+        runner-type: "github"
+    - name: run get-endpoints-self
+      id: get-endpoints-self
+      uses: ./crucible-ci/.github/actions/get-endpoints
+      with:
+        runner-type: "self"
+    - name: run get-benchmarks-github
+      id: get-benchmarks-github
+      uses: ./crucible-ci/.github/actions/get-benchmarks
+      with:
+        runner-type: "github"
+    - name: run get-benchmarks-self
+      id: get-benchmarks-self
+      uses: ./crucible-ci/.github/actions/get-benchmarks
+      with:
+        runner-type: "self"
 
-    - name: Run crucible-ci->integration-tests
+  display-job-matrix-parameters:
+    runs-on: ubuntu-latest
+    needs: generate-job-matrix-parameters
+    steps:
+    - name: Echo generate-job-matrix-parameters outputs
+      run: echo "${{ toJSON(needs.generate-job-matrix-parameters.outputs) }}"
+
+  crucible-ci-github-runners:
+    runs-on: ubuntu-latest
+    needs:
+    - generate-job-matrix-parameters
+    - display-job-matrix-parameters
+    strategy:
+      fail-fast: false
+      matrix:
+        endpoint: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.endpoints_github) }}
+        benchmark: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.benchmarks_github) }}
+        userenv: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.userenvs) }}
+        exclude:
+        - endpoint: "remotehost"
+          benchmark: "oslat"
+    steps:
+    - name: Matrix Parameters => (${{ matrix.endpoint }}, ${{ matrix.benchmark }}, ${{ matrix.userenv }})
+      run: |
+        echo "endpoint=${{ matrix.endpoint }}"
+        echo "benchmark=${{ matrix.benchmark }}"
+        echo "userenv=${{ matrix.userenv }}"
+    - name: checkout workshop
+      uses: actions/checkout@v2
+      with:
+        path: workshop
+    - name: checkout crucible-ci
+      uses: actions/checkout@v2
+      with:
+        repository: perftool-incubator/crucible-ci
+        ref: main
+        path: crucible-ci
+    - name: run crucible-ci->integration-tests
       uses: ./crucible-ci/.github/actions/integration-tests
       with:
-        artifact_tag: "workshop"
+        artifact_tag: "crucible-ci-github-runners__${{ matrix.endpoint }}-${{ matrix.benchmark }}-${{ matrix.userenv }}"
+        ci_endpoint: "${{ matrix.endpoint }}"
+        scenarios: "${{ matrix.benchmark }}"
+        userenvs: "${{ matrix.userenv }}"
+        run_samples: 3
+        repeat_runs: "yes"
         ci_target: "workshop"
         ci_target_dir: ${{ github.workspace }}/workshop
-        userenvs: "all"
+
+  crucible-ci-self-hosted-runners:
+    runs-on: [ self-hosted ]
+    needs:
+    - generate-job-matrix-parameters
+    - display-job-matrix-parameters
+    strategy:
+      fail-fast: false
+      matrix:
+        endpoint: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.endpoints_self) }}
+        benchmark: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.benchmarks_self) }}
+        userenv: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.userenvs) }}
+    steps:
+    - name: Matrix Parameters => (${{ matrix.endpoint }}, ${{ matrix.benchmark }}, ${{ matrix.userenv }})
+      run: |
+        echo "endpoint=${{ matrix.endpoint }}"
+        echo "benchmark=${{ matrix.benchmark }}"
+        echo "userenv=${{ matrix.userenv }}"
+    - name: checkout workshop
+      uses: actions/checkout@v2
+      with:
+        path: workshop
+    - name: checkout crucible-ci
+      uses: actions/checkout@v2
+      with:
+        repository: perftool-incubator/crucible-ci
+        ref: main
+        path: crucible-ci
+    - name: run crucible-ci->integration-tests
+      uses: ./crucible-ci/.github/actions/integration-tests
+      with:
+        artifact_tag: "crucible-ci-self-hosted-runners__${{ matrix.endpoint }}-${{ matrix.benchmark }}-${{ matrix.userenv }}"
+        ci_endpoint: "${{ matrix.endpoint }}"
+        scenarios: "${{ matrix.benchmark }}"
+        userenvs: "${{ matrix.userenv }}"
+        run_samples: 3
+        repeat_runs: "yes"
+        ci_target: "workshop"
+        ci_target_dir: ${{ github.workspace }}/workshop
+
+  crucible-ci-build-controller:
+    runs-on: ubuntu-latest
+    needs:
+    - generate-job-matrix-parameters
+    - display-job-matrix-parameters
+    steps:
+    - name: checkout crucible-ci
+      uses: actions/checkout@v2
+      with:
+        repository: perftool-incubator/crucible-ci
+        ref: main
+        path: crucible-ci
+    - name: run crucible-ci->integration-tests
+      uses: ./crucible-ci/.github/actions/integration-tests
+      with:
+        artifact_tag: "build-controller"
+        ci_build_controller: "yes"
+
+  crucible-ci-complete:
+    runs-on: ubuntu-latest
+    needs:
+    - crucible-ci-github-runners
+    - crucible-ci-self-hosted-runners
+    - crucible-ci-build-controller
+    steps:
+    - name: Confirm Success
+      run: echo "crucible-ci-complete"

--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -1,0 +1,16 @@
+name: faux-crucible-ci
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+    - LICENSE
+    - '**.md'
+    - .github/workflows/faux-crucible-ci.yaml
+    - 'docs/**'
+
+jobs:
+  crucible-ci-complete:
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No build required" '


### PR DESCRIPTION
- test significantly more workshop usage in crucible

  - all userenvs

  - more workloads (fio, uperf, iperf, oslat)

  - all endpoints (remotehost, k8s)

- use scale-out model

- use faux-crucible-ci for documentation related changes