### PR TITLE
schema support for update policy

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -125,6 +125,13 @@
 				"missing",
 				"ifnewer"
 			    ]
+			},
+			"update-policy": {
+			    "type": "string",
+			    "enum": [
+				"always",
+				"never"
+			    ]
 			}
 		    },
 		    "required": [


### PR DESCRIPTION
- Some userenvs need the ability to not automatically perform a package-manager update, as they want exactly what the image contains, and no package updates altering it.  The schema now includes an optional update-policy. To relizze this preference, a caller of workshop still must use --skip-update [true|false] based on the contents of update-policy (or default to true if section is not present).  That code will be in rickshaw-run.