### PR TITLE
allow a single userenv definition to be applied to multiple userenvs …

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -75,7 +75,8 @@
 				"2022.07.25",
 				"2023.02.16",
 				"2024.03.22",
-				"2024.08.07"
+				"2024.08.07",
+				"2025.07.25"
 			    ]
 			}
 		    },
@@ -205,8 +206,21 @@
 		"type": "object",
 		"properties": {
 		    "name": {
-			"type": "string",
-			"minLength": 1
+			"oneOf": [
+			    {
+				"type": "string",
+				"minLength": 1
+			    },
+			    {
+				"type": "array",
+				"minItems": 1,
+				"uniqueItems": true,
+				"items": {
+				    "type": "string",
+				    "minLength": 1
+				}
+			    }
+			]
 		    },
 		    "requirements": {
 			"type": "array",

--- a/workshop.pl
+++ b/workshop.pl
@@ -1430,15 +1430,30 @@ foreach my $tmp_req (@all_requirements) {
     my %userenvs;
 
     for (my $i=0; $i<scalar(@{$tmp_req->{'json'}{'userenvs'}}); $i++) {
-        if (exists($userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}})) {
-            logger('info', "failed\n", 2);
-            logger('error', "Found duplicate userenv definition for '$tmp_req->{'json'}{'userenv'}[$i]{'name'}' in requirements '$tmp_req->{'filename'}'!\n");
-        } else {
-            $userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}} = 1;
-        }
+        if (ref($tmp_req->{'json'}{'userenvs'}[$i]{'name'}) eq 'ARRAY') {
+            for (my $x=0; $x<scalar(@{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}}); $x++) {
+                if (exists($userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}[$x]})) {
+                    logger('info', "failed\n", 2);
+                    logger('error', "Found duplicate userenv definition for '$tmp_req->{'json'}{'userenv'}[$i]{'name'}[$x]' in requirements '$tmp_req->{'filename'}'!\n");
+                } else {
+                    $userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}[$x]} = 1;
+                }
 
-        if ($tmp_req->{'json'}{'userenvs'}[$i]{'name'} eq $userenv_json->{'userenv'}{'name'}) {
-            $userenv_idx = $i;
+                if ($tmp_req->{'json'}{'userenvs'}[$i]{'name'}[$x] eq $userenv_json->{'userenv'}{'name'}) {
+                    $userenv_idx = $i;
+                }
+            }
+        } else {
+            if (exists($userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}})) {
+                logger('info', "failed\n", 2);
+                logger('error', "Found duplicate userenv definition for '$tmp_req->{'json'}{'userenv'}[$i]{'name'}' in requirements '$tmp_req->{'filename'}'!\n");
+            } else {
+                $userenvs{$tmp_req->{'json'}{'userenvs'}[$i]{'name'}} = 1;
+            }
+
+            if ($tmp_req->{'json'}{'userenvs'}[$i]{'name'} eq $userenv_json->{'userenv'}{'name'}) {
+                $userenv_idx = $i;
+            }
         }
 
         if ($tmp_req->{'json'}{'userenvs'}[$i]{'name'} eq 'default') {


### PR DESCRIPTION
…via an array list

- previously a userenv definition could only have a single userenv definition associated with it so when multiple userenvs needed the same definiition then it had to be replicated, for example:

        {
            "name": "alma9",
            "requirements": [
                "deps",
                "numactl_src",
                "rttests_patches",
                "rttests_src_sched",
                "stress-ng_src"
            ]
        },
        {
            "name": "stream9",
            "requirements": [
                "deps",
                "numactl_src",
                "rttests_patches",
                "rttests_src_sched",
                "stress-ng_src"
            ]
        },
        {
            "name": "rhubi9",
            "requirements": [
                "deps",
                "numactl_src",
                "rttests_patches",
                "rttests_src_sched",
                "stress-ng_src"
            ]
        }

- now you should be able to write a single definition that applies to multiple userenvs, for example:

        {
            "name": [
	        "alma9",
		"rhubi9", "stream9 ], "requirements": [ "deps", "numactl_src", "rttests_patches", "rttests_src_sched", "stress-ng_src" ] },

- both the old (name is a string) and new (name is an array) should work so backwards compatibility is maintained