### PR TITLE
fix: fail completion gates when dependencies fail or cancel

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -53,4 +53,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+    - name: Check Results
+      if: >-
+        contains(needs.*.result, 'failure') ||
+        contains(needs.*.result, 'cancelled')
+      run: exit 1
     - run: echo "crucible-ci complete"

--- a/.github/workflows/workshop-ci.yaml
+++ b/.github/workflows/workshop-ci.yaml
@@ -158,4 +158,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+    - name: Check Results
+      if: >-
+        contains(needs.*.result, 'failure') ||
+        contains(needs.*.result, 'cancelled')
+      run: exit 1
     - run: echo "workshop-ci completed successfully"


### PR DESCRIPTION
## Summary

- Add result checking to completion gate jobs (`crucible-ci-complete`, `workshop-ci`) that use `if: always()`
- Gates now fail if any dependency result is `failure` or `cancelled`, preventing false-positive status checks on the branch ruleset
- The existing real/faux skip pattern continues to work — `skipped` results are not treated as failures

## Test plan

- [ ] Verify docs-only PR still skips real CI and passes via faux gate
- [ ] Verify normal PR with all jobs passing still succeeds
- [ ] Verify a cancelled/failed dependency causes the gate to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)