### PR TITLE
feat: add display step for changes action output

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -30,6 +30,8 @@ jobs:
           .github/workflows/crucible-ci.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
+    - name: Display changes
+      run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   call-real-core-release-crucible-ci:
     needs: changes

--- a/.github/workflows/workshop-ci.yaml
+++ b/.github/workflows/workshop-ci.yaml
@@ -32,6 +32,8 @@ jobs:
           .github/workflows/crucible-ci.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
+    - name: Display changes
+      run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   workshop-pl:
     needs: changes


### PR DESCRIPTION
## Summary

Add a Display changes step to log the full tj-actions/changed-files outputs for visibility in the GitHub UI.

Tracking: perftool-incubator/crucible#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)