### PR TITLE
feat: add workshop.json with controller image requirements

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -1,0 +1,53 @@
+{
+    "workshop": {
+        "schema": {
+            "version": "2020.03.02"
+        }
+    },
+    "userenvs": [
+        {
+            "name": "crucible-controller",
+            "requirements": [
+                "workshop-perl-modules",
+                "python3-invoke",
+                "workshop-container-tools"
+            ]
+        }
+    ],
+    "requirements": [
+        {
+            "name": "workshop-perl-modules",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "perl-JSON",
+                    "perl-JSON-Validator",
+                    "perl-Digest-SHA",
+                    "perl-Data-UUID",
+                    "perl-Data-Dumper",
+                    "perl-Getopt-Long",
+                    "perl-Coro"
+                ]
+            }
+        },
+        {
+            "name": "python3-invoke",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "python3-invoke"
+                ]
+            }
+        },
+        {
+            "name": "workshop-container-tools",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "buildah",
+                    "skopeo"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Add `workshop.json` declaring workshop's own dependencies for the controller image build:
  - Perl modules for workshop.pl (JSON, JSON-Validator, Digest-SHA, Data-UUID, Data-Dumper, Getopt-Long, Coro)
  - python3-invoke for workshop.py
  - buildah and skopeo for container image building

Part of the effort to decentralize controller image requirements to individual subprojects.

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully with workshop deps resolved from this workshop.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)