### PR TITLE
feat: add controller-build workflow and update CI exclusions

### DIFF
--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -1,0 +1,22 @@
+name: controller-build
+
+on:
+  pull_request_target:
+    types: [ closed ]
+    branches: [ master ]
+    paths:
+      - workshop.json
+      - .github/workflows/controller-build.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: build-publish-controller
+  cancel-in-progress: true
+
+jobs:
+  call-build-publish-controller:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    uses: perftool-incubator/crucible/.github/workflows/build-publish-controller.yaml@master
+    with:
+      ci_target: "workshop"
+    secrets: inherit

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -28,6 +28,7 @@ jobs:
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-merged.yaml
           .github/workflows/crucible-ci.yaml
+            .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
     - name: Display changes

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -28,7 +28,7 @@ jobs:
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-merged.yaml
           .github/workflows/crucible-ci.yaml
-            .github/workflows/controller-build.yaml
+          .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
     - name: Display changes

--- a/.github/workflows/workshop-ci.yaml
+++ b/.github/workflows/workshop-ci.yaml
@@ -30,6 +30,7 @@ jobs:
           .github/rulesets/**
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-ci.yaml
+          .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
     - name: Display changes


### PR DESCRIPTION
## Summary
- Add `controller-build.yaml` caller workflow to trigger an automated controller image build when `workshop.json` changes are merged
- Update CI workflow exclusion lists to skip heavy CI when only controller-build workflow files change

## Test plan
- [ ] CI passes (should skip heavy CI since only workflow files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)