### PR TITLE
feat: switch controller-build to repository_dispatch

### DIFF
--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -9,14 +9,24 @@ on:
       - .github/workflows/controller-build.yaml
   workflow_dispatch:
 
-concurrency:
-  group: build-publish-controller
-  cancel-in-progress: true
-
 jobs:
-  call-build-publish-controller:
+  dispatch:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: perftool-incubator/crucible/.github/workflows/build-publish-controller.yaml@master
-    with:
-      ci_target: "workshop"
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID__CRUCIBLE_WORKFLOW_DISPATCH }}
+          private-key: ${{ secrets.PRIVATE_KEY__CRUCIBLE_WORKFLOW_DISPATCH }}
+          owner: perftool-incubator
+          repositories: crucible
+
+      - name: Dispatch controller build
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/perftool-incubator/crucible/dispatches" \
+            -d '{"event_type":"controller-build","client_payload":{"ci_target":"workshop"}}'


### PR DESCRIPTION
## Summary
- Replace reusable workflow call with `repository_dispatch` to crucible
- All controller builds now run in crucible's context with working cross-repo concurrency
- Uses a GitHub App token (`actions/create-github-app-token`) to dispatch

## Test plan
- [ ] CI passes (should skip heavy CI since only workflow file changed)
- [ ] After merge, controller-build workflow dispatches to crucible successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)