### PR TITLE
feat: block fork PRs and skip CI for fork-originated pull requests

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -28,6 +28,7 @@ jobs:
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-merged.yaml
           .github/workflows/crucible-ci.yaml
+            .github/workflows/fork-check.yaml
           .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
@@ -36,7 +37,7 @@ jobs:
 
   call-real-core-release-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "workshop"
@@ -48,7 +49,7 @@ jobs:
 
   call-faux-core-release-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:

--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -1,0 +1,27 @@
+name: fork-check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  block-fork-pr:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close fork PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This PR was opened from a fork. PRs must be opened from branches on the upstream repository so that CI workflows have access to required secrets and variables.\n\nPlease push your branch to this repository and open a new PR.\n\nClosing this PR automatically.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });

--- a/.github/workflows/workshop-ci.yaml
+++ b/.github/workflows/workshop-ci.yaml
@@ -30,6 +30,7 @@ jobs:
           .github/rulesets/**
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-ci.yaml
+            .github/workflows/fork-check.yaml
           .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**
@@ -38,7 +39,7 @@ jobs:
 
   workshop-pl:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     runs-on: [ self-hosted, aws-cloud-1 ]
 
     steps:
@@ -94,7 +95,7 @@ jobs:
 
   workshop-py:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     runs-on: [ self-hosted, aws-cloud-1 ]
 
     steps:
@@ -151,7 +152,7 @@ jobs:
 
   faux-workshop-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - run: echo "faux-workshop-ci complete"


### PR DESCRIPTION
## Summary
- Add `fork-check.yaml` workflow that automatically comments and closes PRs from forks
- Add fork guard to all PR-triggered CI workflows
- Add `fork-check.yaml` to CI exclusion lists

Part of an org-wide rollout across all repos.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)