### PR TITLE
fix: add --security-opt label=disable to buildah from (2025.3)

### DIFF
--- a/workshop.pl
+++ b/workshop.pl
@@ -1887,7 +1887,7 @@ if ($remove_image) {
 
 # create a new container based on the userenv source
 logger('info', "Creating temporary container...\n");
-($command, $command_output, $rc) = run_command("buildah from --name $tmp_container $origin_image_id");
+($command, $command_output, $rc) = run_command("buildah from --security-opt label=disable --name $tmp_container $origin_image_id");
 if ($rc != 0) {
     logger('info', "failed\n", 1);
     command_logger('error', $command, $rc, $command_output);


### PR DESCRIPTION
## Summary
Backport SELinux buildah fix to 2025.3. Fixes DNS resolution failures during engine image builds on systems with SELinux enforcing.

Adds `--security-opt label=disable` to `buildah from` to prevent SELinux MCS category mismatch when buildah runs inside a podman container.

## Test plan
- [ ] Build an engine image on a system with SELinux enforcing
- [ ] Verify DNS resolution works inside the buildah chroot

🤖 Generated with [Claude Code](https://claude.com/claude-code)