### PR TITLE
fix: CI workflow fixes for fork-check permissions and only_changed

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -28,7 +28,7 @@ jobs:
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-merged.yaml
           .github/workflows/crucible-ci.yaml
-            .github/workflows/fork-check.yaml
+          .github/workflows/fork-check.yaml
           .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**

--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -2,7 +2,11 @@ name: fork-check
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   block-fork-pr:

--- a/.github/workflows/workshop-ci.yaml
+++ b/.github/workflows/workshop-ci.yaml
@@ -30,7 +30,7 @@ jobs:
           .github/rulesets/**
           .github/workflows/run-crucible-tracking.yaml
           .github/workflows/crucible-ci.yaml
-            .github/workflows/fork-check.yaml
+          .github/workflows/fork-check.yaml
           .github/workflows/controller-build.yaml
           .github/workflows/workshop-ci.yaml
           docs/**


### PR DESCRIPTION
## Summary

CI workflow fixes:

1. **fork-check.yaml**: Add `permissions` block (`issues: write`, `pull-requests: write`) and broaden event types to include `synchronize` and `edited`.

## Test plan

- [ ] Fork-check: verified working on bench-trafficgen#106
- [ ] only_modified: verify CI runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)