### PR TITLE
fix: apt-get flag, schema typos, install_files error handling, port max

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -759,7 +759,7 @@
 			"description": "A port number to expose.",
 			"type": "integer",
 			"minimum": 1,
-			"maximum": 65536
+			"maximum": 65535
 		    }
 		},
 		"labels": {

--- a/schema.json
+++ b/schema.json
@@ -299,7 +299,7 @@
 					"description": "An array of package names to install using the distribution's package manager.",
 					"type": "array",
 					"minItems": 1,
-					"uniqueuItems": true,
+					"uniqueItems": true,
 					"items": {
 					    "type": "string",
 					    "minLength": 1
@@ -353,7 +353,7 @@
 					"description": "An array of package names to install or remove.",
 					"type": "array",
 					"minItems": 1,
-					"uniqueuItems": true,
+					"uniqueItems": true,
 					"items": {
 					    "type": "string",
 					    "minLength": 1
@@ -363,7 +363,7 @@
 					"description": "An array of package group names to install or remove.",
 					"type": "array",
 					"minItems": 1,
-					"uniqueuItems": true,
+					"uniqueItems": true,
 					"items": {
 					    "type": "string",
 					    "minLength": 1

--- a/workshop.py
+++ b/workshop.py
@@ -652,12 +652,14 @@ def install_files(req, container, params, offset):
                 log(logging.INFO, "failed", offset + 1)
                 command_log(logging.ERROR, command, rc, command_output)
                 log(logging.ERROR, "Failed to copy '%s' to the temporary container" % src)
+                sys.exit(get_exit_code('build_failed'))
             else:
                 log(logging.INFO, "succeeded", offset + 1)
                 command_log(VERBOSE, command, rc, command_output)
         else:
             log(logging.INFO, "failed", offset + 1)
-            log(logging.ERROR, "Destination not defined for '%s'" % src)
+            log(logging.ERROR, "Destination not defined for '%s' (should be enforced by schema)" % src)
+            sys.exit(get_exit_code('build_failed'))
 
 
 def install_distro_manual(req, container, userenv_json, offset):

--- a/workshop.py
+++ b/workshop.py
@@ -818,7 +818,7 @@ def _get_group_cmd(manager, operation, grp):
     cmds = {
         'dnf': {'install': 'dnf groupinstall --allowerasing --assumeyes %s', 'remove': 'dnf groupremove --assumeyes %s'},
         'yum': {'install': 'yum groupinstall --assumeyes %s', 'remove': 'yum groupremove --assumeyes %s'},
-        'apt': {'install': 'apt-get install -y --assumeyes %s', 'remove': 'apt-get remove -y --assumeyes %s'},
+        'apt': {'install': 'apt-get install -y %s', 'remove': 'apt-get remove -y %s'},
         'zypper': {'install': 'zypper install -y -t pattern %s', 'remove': 'zypper remove -y -t pattern %s'},
     }
     if manager not in cmds:


### PR DESCRIPTION
## Summary

Four fixes, one per commit:

- **Remove `--assumeyes` from apt-get**: `--assumeyes` is a dnf/yum flag, not valid for apt-get (which already has `-y`). Would cause group install/remove to fail on Debian/Ubuntu userenvs.

- **Fix misspelled `uniqueuItems` in schema**: Three instances of `"uniqueuItems"` (extra `u`) silently ignored by validators. Duplicate items in `distro-manual_info.packages`, `distro_info.packages`, and `distro_info.groups` arrays were not rejected.

- **Exit on `install_files` failure**: Every other `install_*` function calls `sys.exit()` on failure, but `install_files` logged errors and continued — silently producing images with missing files. The missing-destination guard is defense-in-depth (schema requires `dst`).

- **Port maximum 65536 → 65535**: Valid TCP/UDP port range is 1-65535.

Closes #120

## Test plan
- [ ] `python3 -c "import json; json.load(open('schema.json'))"` — valid JSON
- [ ] Build an image with an apt-based userenv — verify group install doesn't fail on `--assumeyes`
- [ ] Review `install_files` exit behavior matches other `install_*` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)